### PR TITLE
Restrict checks to class files only

### DIFF
--- a/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesTask.groovy
+++ b/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesTask.groovy
@@ -64,7 +64,7 @@ class CheckDuplicateClassesTask extends DefaultTask implements VerificationTask 
         configuration.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             logger.info( "    '${artifact.file.path}' of '${artifact.moduleVersion}'" )
 
-            new ZipFile( artifact.file ).entries().each { entry ->
+            new ZipFile( artifact.file ).entries().findAll{ it.name.endsWith(".class") }.each { entry ->
                 if ( !entry.isDirectory() && !entry.name.startsWith( 'META-INF/' ) ) {
                     final Set modules = modulesByFile.get( entry.name )
                     modules.add( artifact.moduleVersion.toString() )


### PR DESCRIPTION
Hey there, been looking at attempting to use this and came across an issue that this not only checks for duplicate class files but also any other extra file contained within the jar. For example all of jacocos projects have a 'about.html' and this tool flags those as duplicates. This little filter intends to restrict the scope of the tool