### PR TITLE
Add a way to exclude entries

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,3 +18,10 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'com.datastax.cassandra:cassandra-driver-core:3.4.0'
 }
+
+checkForDuplicateClasses {
+    exclusions = [
+            "com/mchange/Debug.class",
+            "com/mchange/v2/Debug.class"
+    ]
+}


### PR DESCRIPTION
This PR adds the possibility to exclude certain classes and files. Its intended to be used to exclude `about.html` or `package-info.class` files. It would also fix #2 

This first iteration just adds a list of things to exclude, no fancy globbing or such things.