### PR TITLE
Analysis and report improvements

### DIFF
--- a/src/functionalTest/groovy/net/idlestate/gradle/duplicates/PluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/net/idlestate/gradle/duplicates/PluginFunctionalTest.groovy
@@ -37,13 +37,11 @@ class PluginFunctionalTest {
 
     def expectedLines = [
             "com.fasterxml.woodstox:woodstox-core:5.1.0, org.codehaus.woodstox:woodstox-core-asl:4.2.0",
-            "org.apache.cassandra:cassandra-all:1.2.11, org.apache.cassandra:cassandra-thrift:1.2.11",
             "com.sun.xml.bind:jaxb-core:2.3.0, org.glassfish.jaxb:jaxb-runtime:2.3.2",
             "com.sun.xml.bind:jaxb-impl:2.3.0, org.glassfish.jaxb:jaxb-runtime:2.3.2",
             "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2, javax.xml.bind:jaxb-api:2.3.0",
             "com.sun.istack:istack-commons-runtime:3.0.8, com.sun.xml.bind:jaxb-core:2.3.0",
             "com.sun.xml.bind:jaxb-core:2.3.0, org.glassfish.jaxb:txw2:2.3.2",
-            "com.sun.istack:istack-commons-runtime:3.0.8, com.sun.xml.bind:jaxb-xjc:2.3.1",
             "org.apache.logging.log4j:log4j-slf4j-impl:2.11.2, org.slf4j:slf4j-log4j12:1.7.21",
             "jakarta.jws:jakarta.jws-api:1.1.1, org.apache.geronimo.specs:geronimo-ws-metadata_2.0_spec:1.1.2",
             "jakarta.persistence:jakarta.persistence-api:2.2.3, org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final",
@@ -160,7 +158,7 @@ class PluginFunctionalTest {
 
     private void checkForExpectedLines(def message) {
         for (def expected : expectedLines) {
-            Assert.assertTrue(message.contains(expected))
+            Assert.assertTrue("Doesn't contain " + expected, message.contains(expected))
         }
     }
 

--- a/src/main/groovy/net/idlestate/gradle/duplicates/FileToVersion.groovy
+++ b/src/main/groovy/net/idlestate/gradle/duplicates/FileToVersion.groovy
@@ -18,17 +18,18 @@
 package net.idlestate.gradle.duplicates
 
 class FileToVersion {
-        String file
+    private String file
+    private long crc
+    private String version
 
-        String version
-
-        FileToVersion(String file, String version) {
-            this.file = file
-            this.version = version
-        }
+    FileToVersion(String file, long crc, String version) {
+        this.file = file
+        this.crc = crc
+        this.version = version
+    }
 
     @Override
     String toString() {
-        return "file: ${file} version: ${version}"
+        return "file: ${file} crc: ${crc} version: ${version}"
     }
 }

--- a/src/test/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngineTest.groovy
+++ b/src/test/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngineTest.groovy
@@ -40,7 +40,7 @@ class CheckDuplicateClassesEngineTest extends GroovyTestCase {
 
     @Test
     void testSearchForDuplicates() {
-        def engine = new CheckDuplicateClassesEngine([] as List, [] as List)
+        def engine = new CheckDuplicateClassesEngine([] as List, [] as List, [] as List)
 
         Path libsPath = testJarsPath()
 
@@ -74,7 +74,7 @@ class CheckDuplicateClassesEngineTest extends GroovyTestCase {
 
     @Test
     void testExcludeJarFiles() {
-        def engine = new CheckDuplicateClassesEngine(['^.*(jakarta).*(.jar)$'], [] as List)
+        def engine = new CheckDuplicateClassesEngine(['^.*(jakarta).*(.jar)$'], [] as List, [] as List)
         Path libsPath = testJarsPath()
 
         Map<String, Set> modulesByFile = processArtifacts(libsPath, engine)
@@ -91,7 +91,7 @@ class CheckDuplicateClassesEngineTest extends GroovyTestCase {
 
     @Test
     def testReportGenerator() {
-        def engine = new CheckDuplicateClassesEngine([] as List, [] as List)
+        def engine = new CheckDuplicateClassesEngine([] as List, [] as List, [] as List)
 
         Path libsPath = testJarsPath()
 
@@ -119,13 +119,12 @@ class CheckDuplicateClassesEngineTest extends GroovyTestCase {
         }.collect()
 
         classesByJar = artifactsPath.stream().flatMap { jar ->
-            engine.processArtifact(jar).stream().
-                    map { new FileToVersion(it, jar.name) }
+            engine.processArtifact(jar, jar.name).stream()
         }.collect(concurrentMapCollector())
 
         classesByJar.entrySet().stream().flatMap { es ->
             es.value.stream().map {
-                new FileToVersion(es.key, it)
+                new FileToVersion(es.key, 0, it)
             }
         }.collect(concurrentMapCollector())
     }


### PR DESCRIPTION
First of all, great work guys! This plugin has helped us avoid serious issues on multiple occasions. 

Having said that there are a few improvements we'd like to introduce with this pr:

1) avoid false positives by checking checksums of duplicates
Various vendors tend to include identical interfaces in their JARs. A good example is cassandra from the funtcional test. These identical interfaces do not introduce a problem - the code will work in exactly the same way regardless of their order on the classpath

2) adding an ability to exclude modules
Excluding JARs based on regex is useful but is hard to use with local modules. Excluding based on class names did not prove useful to us as refactoring normally breaks this.

3) removing non duplicate classes from the report
The report in its current form is hard to use as it has all classes so this patch removes classes that are not causing issues.