### PR TITLE
Various changes that will handle some of the open issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 apply plugin: 'groovy'
@@ -54,7 +54,7 @@ def functionalTestTask = tasks.register("functionalTest", Test) {
 }
 
 check {
-    dependsOn(functionalTestTask)
+    dependsOn functionalTestTask
 }
 
 pluginBundle {

--- a/src/functionalTest/groovy/net/idlestate/gradle/duplicates/PluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/net/idlestate/gradle/duplicates/PluginFunctionalTest.groovy
@@ -101,7 +101,9 @@ class PluginFunctionalTest {
             "org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:1.0.1.Final",
             "commons-logging:commons-logging:1.2",
             "org.slf4j:jcl-over-slf4j:1.7.26",
-            "org.springframework:spring-jcl:5.2.8.RELEASE"
+            "org.springframework:spring-jcl:5.2.8.RELEASE",
+            // Non-zip dependency
+            "org.graalvm.polyglot:llvm-community:24.2.1@pom"
           )
         }
         """
@@ -122,7 +124,7 @@ class PluginFunctionalTest {
 
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments('checkForDuplicateClasses')
+                .withArguments('check')
                 .withPluginClasspath()
                 .build()
 
@@ -147,7 +149,7 @@ class PluginFunctionalTest {
         try {
             GradleRunner.create()
                     .withProjectDir(testProjectDir.root)
-                    .withArguments('checkForDuplicateClasses')
+                    .withArguments('check')
                     .withPluginClasspath()
                     .build()
             fail()
@@ -178,7 +180,7 @@ class PluginFunctionalTest {
 
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments('checkForDuplicateClasses')
+                .withArguments('check')
                 .withPluginClasspath()
                 .build()
 

--- a/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngine.groovy
+++ b/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngine.groovy
@@ -16,9 +16,11 @@
  */
 package net.idlestate.gradle.duplicates
 
-import org.gradle.api.GradleException
+import org.gradle.api.Task
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.logging.Logging
+
 import java.nio.file.Path
 import java.util.function.Consumer
 import java.util.regex.Pattern
@@ -26,7 +28,11 @@ import java.util.stream.Collector
 import java.util.stream.Collectors
 import java.util.zip.ZipFile
 
+import org.gradle.api.logging.Logger;
+
 class CheckDuplicateClassesEngine {
+    private static final Logger logger = Logging.getLogger(Task.class);
+
     private static final List<String> defaultExclude =
             Arrays.asList('^(META-INF/).*',
                     '^(OSGI-INF/).*',
@@ -39,11 +45,11 @@ class CheckDuplicateClassesEngine {
                     '^(LICENSE)',
                     '^(NOTICE)')
 
-    private Pattern excludePattern
+    private final Pattern excludePattern
 
-    private Pattern includePattern
+    private final Pattern includePattern
 
-    private List<ModuleIdentifier> excludeModules
+    private final List<ModuleIdentifier> excludeModules
 
     CheckDuplicateClassesEngine(List<String> excludes, List<ModuleIdentifier> excludeModules, List<String> includes) {
         excludes.addAll(defaultExclude)
@@ -57,12 +63,18 @@ class CheckDuplicateClassesEngine {
         if (artifact.moduleVersion != null) {
             ModuleIdentifier identifier = artifact.moduleVersion.id.module
             return excludeModules.stream().anyMatch {
-                it.name.equals(identifier.name) && it.group.equals(identifier.group)
+                it.name == identifier.name && it.group == identifier.group
             }
         }
         return false;
     }
 
+    /**
+     * This method consumes both File and ZipEntry. It requires isDirectory method and name property
+     *
+     * @param entry
+     * @return true if the entry is a file and not in the excluded list
+     */
     boolean isValidEntry(final entry) {
         if (entry.isDirectory()) {
             return false
@@ -125,10 +137,19 @@ class CheckDuplicateClassesEngine {
         }
 
         if (!artifactFile.exists()) {
-            throw new GradleException("File `$artifactFile.path` does not exist!!!")
+            logger.warn("File `$artifactFile.path` does not exist!!!")
         }
 
-        new ZipFile(artifactFile).stream().
+        def zipFile
+
+        try {
+            zipFile = new ZipFile(artifactFile)
+        } catch (ignored) {
+            logger.warn("File $artifactFile.path is not a valid ZIP archive!")
+            return Collections.emptyList()
+        }
+
+        zipFile.stream().
                 filter({ isValidEntry(it) }).
                 map({ new FileToVersion(it.name, it.crc, version) }).
                 collect(Collectors.toList())
@@ -191,11 +212,7 @@ class CheckDuplicateClassesEngine {
             def tempFileName = "duplicate_classes" + it.hashCode() + ".html"
             indexHtml.append('<li>').append('<a href="').append(tempFileName).append('">').append(it.stream().collect(Collectors.joining(","))).append('</a></li><br/>\n')
             Collections.singletonMap(tempFileName, it).entrySet().stream()
-        }.collect(Collectors.toMap({
-            it.getKey()
-        }, {
-            it.getValue()
-        }))
+        }.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
 
         duplicateMap.keySet().forEach {
             result.put(it, generateDuplicateClassesReport(new ArrayList<String>(duplicateMap.get(it)), classesByArtifactMap))

--- a/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesPlugin.groovy
+++ b/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesPlugin.groovy
@@ -28,13 +28,13 @@ class CheckDuplicateClassesPlugin implements Plugin<Project> {
 
     @Override
     void apply(final Project project) {
-        final Task checkForDuplicateClasses = project.task(
-                'checkForDuplicateClasses',
-                type: CheckDuplicateClassesTask,
-                group: LifecycleBasePlugin.VERIFICATION_GROUP,
-                description: 'Checks whether there are modules that provide the same classes.'
-        )
+        def taskProvider = project.tasks.register('checkForDuplicateClasses', CheckDuplicateClassesTask) { task ->
+            group = LifecycleBasePlugin.VERIFICATION_GROUP
+            description = 'Checks whether there are modules that provide the same classes.'
+        }
 
-        project.getTasksByName( LifecycleBasePlugin.CHECK_TASK_NAME, false )*.dependsOn checkForDuplicateClasses
+        project.afterEvaluate {
+            project.getTasksByName(LifecycleBasePlugin.CHECK_TASK_NAME, false)*.dependsOn taskProvider
+        }
     }
 }

--- a/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesTask.groovy
+++ b/src/main/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesTask.groovy
@@ -66,11 +66,12 @@ class CheckDuplicateClassesTask extends DefaultTask implements VerificationTask 
             prepareReportsDirectory()
         }
 
-        Map<Configuration, Collection<List<String>>> configurationResult = configurationsToCheck.stream().filter { isConfigurationResolvable(it) }.
-                collect(Collectors.toMap({ it }, {
-                    logger.info("Checking configuration '${it.name}'")
-                    checkConfiguration(it, engine)
-                }))
+        Map<Configuration, Collection<List<String>>> configurationResult =
+                configurationsToCheck.stream().filter { isConfigurationResolvable(it) }.
+                        collect(Collectors.toMap({ it }, {
+                            logger.info("Checking configuration '${it.name}'")
+                            checkConfiguration(it as Configuration, engine)
+                        }))
 
         if (configurationResult.isEmpty() || configurationResult.values().findAll({ !it.isEmpty() }).isEmpty()) {
             return
@@ -84,11 +85,12 @@ class CheckDuplicateClassesTask extends DefaultTask implements VerificationTask 
             return
         }
 
-        if (!project.buildDir.exists()) {
-            project.buildDir.mkdir()
+        def buildDir = project.layout.getBuildDirectory().asFile
+        if (!buildDir.filter { it.exists() }.isPresent()) {
+            buildDir.get().mkdir()
         }
 
-        def reportDir = project.buildDir.toPath().resolve("reports").toFile()
+        def reportDir = buildDir.get().toPath().resolve("reports").toFile()
         if (!reportDir.exists()) {
             reportDir.mkdir()
         }
@@ -135,12 +137,12 @@ class CheckDuplicateClassesTask extends DefaultTask implements VerificationTask 
 
         Map<String, List<FileToVersion>> duplicateClasses = artifactsStream.
                 flatMap { processArtifact(it, engine).stream() }.
-                collect(Collectors.groupingBy{it.file})
+                collect(Collectors.groupingBy { it.file })
 
         duplicateClasses = duplicateClasses.entrySet().stream().
                 filter { it.value.size() > 1 }.
-                filter { a -> a.value.stream().anyMatch { b -> b.crc != a.value.get(0).crc }}.
-                collect(Collectors.toMap({it.key},{it.value}))
+                filter { a -> a.value.stream().anyMatch { b -> b.crc != a.value.get(0).crc } }.
+                collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
 
         classesByArtifactMap = duplicateClasses.
                 values().
@@ -149,7 +151,7 @@ class CheckDuplicateClassesTask extends DefaultTask implements VerificationTask 
                 collect(Collectors.groupingBy({ it.version }, Collectors.mapping({ it.file }, Collectors.toSet())))
 
         Map<String, Set<String>> jarsByClassMap = duplicateClasses.entrySet().stream().collect(
-                Collectors.toMap({it.key}, {it.value.stream().map({it.version}).collect(Collectors.toSet())}))
+                Collectors.toMap(Map.Entry::getKey, { it.value.stream().map({ it.version }).collect(Collectors.toSet()) }))
 
         return searchForDuplicates(jarsByClassMap, logger.isInfoEnabled() ? { logger.info(it) } : null)
     }
@@ -169,7 +171,7 @@ class CheckDuplicateClassesTask extends DefaultTask implements VerificationTask 
      * Gradle 3.4 introduced the configuration 'apiElements' that isn't resolvable. So
      * we have to check before accessing it.
      */
-    static boolean isConfigurationResolvable(configuration) {
+    static boolean isConfigurationResolvable(Configuration configuration) {
         if (!configuration.metaClass.respondsTo(configuration, 'isCanBeResolved')) {
             // If the recently introduced method 'isCanBeResolved' is unavailable, we
             // assume (for now) that the configuration can be resolved.
@@ -219,12 +221,12 @@ class CheckDuplicateClassesTask extends DefaultTask implements VerificationTask 
     }
 
     CheckDuplicateClassesTask excludeModule(String excludeModule) {
-        String[] splitted = excludeModule.split(':')
-        if (splitted.size() != 2) {
+        String[] split = excludeModule.split(':')
+        if (split.size() != 2) {
             throw new GradleException('Specify module identifier as "group:name" got "' + excludeModule + '"')
         }
 
-        this.excludeModules.add(DefaultModuleIdentifier.newId(splitted[0], splitted[1]))
+        this.excludeModules.add(DefaultModuleIdentifier.newId(split[0], split[1]))
         this
     }
 

--- a/src/main/groovy/net/idlestate/gradle/duplicates/FileToVersion.groovy
+++ b/src/main/groovy/net/idlestate/gradle/duplicates/FileToVersion.groovy
@@ -18,9 +18,9 @@
 package net.idlestate.gradle.duplicates
 
 class FileToVersion {
-    private String file
-    private long crc
-    private String version
+    final String file
+    final long crc
+    final String version
 
     FileToVersion(String file, long crc, String version) {
         this.file = file

--- a/src/test/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngineTest.groovy
+++ b/src/test/groovy/net/idlestate/gradle/duplicates/CheckDuplicateClassesEngineTest.groovy
@@ -42,7 +42,7 @@ class CheckDuplicateClassesEngineTest extends GroovyTestCase {
     void testSearchForDuplicates() {
         def engine = new CheckDuplicateClassesEngine([] as List, [] as List, [] as List)
 
-        Path libsPath = testJarsPath()
+        Path libsPath = jarsPath()
 
         Map<String, Set> modulesByFile =
                 processArtifacts(libsPath, engine)
@@ -58,7 +58,7 @@ class CheckDuplicateClassesEngineTest extends GroovyTestCase {
         }
     }
 
-    private Path testJarsPath() {
+    private Path jarsPath() {
         URL resourceUrl = getClass().getClassLoader().getResource("libs")
 
         Paths.get(resourceUrl.toURI())
@@ -76,7 +76,7 @@ class CheckDuplicateClassesEngineTest extends GroovyTestCase {
     @Test
     void testExcludeJarFiles() {
         def engine = new CheckDuplicateClassesEngine(['^.*(jakarta).*(.jar)$'], [] as List, [] as List)
-        Path libsPath = testJarsPath()
+        Path libsPath = jarsPath()
 
         Map<String, Set> modulesByFile = processArtifacts(libsPath, engine)
 
@@ -91,10 +91,10 @@ class CheckDuplicateClassesEngineTest extends GroovyTestCase {
     }
 
     @Test
-    def testReportGenerator() {
+    void testReportGenerator() {
         def engine = new CheckDuplicateClassesEngine([] as List, [] as List, [] as List)
 
-        Path libsPath = testJarsPath()
+        Path libsPath = jarsPath()
 
         Map<String, Set> modulesByFile =
                 processArtifacts(libsPath, engine)
@@ -133,7 +133,7 @@ class CheckDuplicateClassesEngineTest extends GroovyTestCase {
     static void main(String[] args) {
         def test = new CheckDuplicateClassesEngineTest()
         Map<String, String> reportMap = test.testReportGenerator()
-        def libsPath = test.testJarsPath()
+        def libsPath = test.jarsPath()
         def reportsPath = libsPath.resolve("..").resolve("..").resolve("..").resolve("..").resolve("build").resolve("reports")
         CheckDuplicateClassesEngine.writeReportFiles(reportsPath, reportMap)
     }


### PR DESCRIPTION
non-zip artifacts are properly handled and don't crash the check process anymore. Log warning message instead

Log warning instead of throwing an exception if the artifact that has to be checked can't be found on the file system. 

Change how the task is registered and attached to the _check_ task.

Change the functional test to verify that plugin task is properly attached to the _check_ task 

Use **project.layout** instead of **project.buildDir**.